### PR TITLE
Fix highlighting keyword

### DIFF
--- a/php-ts-mode.el
+++ b/php-ts-mode.el
@@ -76,10 +76,10 @@
     "elseif" "enddeclare" "endforeach" "endif" "endswitch"
     "endwhile" "enum" "extends" "final" "finally" "for" "foreach"
     "fn" "function" "global" "if" "implements" "include_once"
-    "include" "insteadof" "interface" "namespace" "never" "new"
+    "include" "insteadof" "interface" "namespace" "new"
     "private" "protected" "public" "readonly" "require_once" "require"
     "return" "static" "switch" "throw" "trait" "try" "use"
-    "while" "yield" "yield from")
+    "while" "yield")
   "PHP keywords for tree-sitter font-locking.")
 
 (defvar php-ts-mode--operators
@@ -208,7 +208,9 @@ the available version of Tree-sitter for PHP."
 
    :language 'php
    :feature 'keyword
-   `([,@php-ts-mode--keywords] @font-lock-keyword-face)
+   `([,@php-ts-mode--keywords] @font-lock-keyword-face
+     ;; TODO: Add "yield from"
+     )
 
    :language 'php
    :feature 'bracket


### PR DESCRIPTION
Quick fix https://github.com/emacs-php/php-ts-mode/pull/9

Words not defined as keywords cause highlighting errors:

<img width="1315" alt="スクリーンショット 2023-05-22 22 31 54" src="https://github.com/emacs-php/php-ts-mode/assets/822086/ec7b0cae-004d-4dd4-8aad-9619908d1e37">

```
Error during redisplay: (jit-lock-function 1) signaled (treesit-query-error "Node type error at" 473 "[\"abstract\" \"as\" \"break\" \"case\" \"catch\" \"class\" \"const\" \"continue\" \"declare\" \"default\" \"do\" \"echo\" \"else\" \"elseif\" \"enddeclare\" \"endforeach\" \"endif\" \"endswitch\" \"endwhile\" \"enum\" \"extends\" \"final\" \"finally\" \"for\" \"foreach\" \"fn\" \"function\" \"global\" \"if\" \"implements\" \"include_once\" \"include\" \"insteadof\" \"interface\" \"namespace\" \"new\" \"private\" \"protected\" \"public\" \"readonly\" \"require_once\" \"require\" \"return\" \"static\" \"switch\" \"throw\" \"trait\" \"try\" \"use\" \"while\" \"yield\" \"yield from\"] @font-lock-keyword-face" "Debug the query with `treesit-query-validate'")
```
