### PR TITLE
add never as type

### DIFF
--- a/php-ts-mode.el
+++ b/php-ts-mode.el
@@ -120,6 +120,7 @@ the available version of Tree-sitter for PHP."
    :feature 'type
    `([(primitive_type)
       (cast_type)
+      (bottom_type)
       (named_type (name) @type)
       (named_type (qualified_name) @type)
       (namespace_use_clause)


### PR DESCRIPTION
Refs https://github.com/emacs-php/php-ts-mode/issues/8
Shows as expected:
![phptsnever](https://github.com/emacs-php/php-ts-mode/assets/2151333/ad0a70fc-dd7c-4e17-95ba-59b2f36a92fe)
