### PR TITLE
basic tests wip

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    paths-ignore:
+    - '**/*.md'
+    - 'etc/*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    strategy:
+      matrix:
+        emacs_version: ['release-snapshot']
+    steps:
+    - name: Install emacs
+      run: sudo snap install emacs --beta --classic
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Check emacs version
+      run: emacs --version
+    - name: Emacs support
+      run: emacs --batch --eval '(message "Treesit available %s" (treesit-available-p))'
+    - name: Run tests
+      run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.elc
+php-ts-mode-autoloads.el
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+EMACS ?= emacs
+ELS = php-ts-mode.el
+ELS += php-face.el
+ELCS = $(ELS:.el=.elc)
+AUTOLOADS = php-ts-mode-autoloads.el
+
+%.elc: %.el
+	$(EMACS) --batch -L $(ELS) -f batch-byte-compile $<
+
+all: autoloads $(ELCS)
+
+autoloads: $(AUTOLOADS)
+
+$(AUTOLOADS): $(ELS)
+	$(EMACS) --batch -L $(ELS) --eval \
+	"(let ((user-emacs-directory default-directory)) \
+	   (require 'package) \
+	   (package-generate-autoloads \"php-ts-mode\" (expand-file-name \".\")))"
+
+clean:
+	rm -rf $(ELCS) $(AUTOLOADS) tree-sitter
+
+test: clean all
+	$(EMACS) --batch \
+		-l php-ts-mode-autoloads.el \
+		--eval \
+		"(progn \
+		  (require 'treesit) \
+		  (declare-function treesit-install-language-grammar \"treesit.c\") \
+		  (if (and (treesit-available-p) (boundp 'treesit-language-source-alist)) \
+		      (unless (treesit-language-available-p 'php) \
+		        (add-to-list \
+		         'treesit-language-source-alist \
+		         '(php . (\"https://github.com/tree-sitter/tree-sitter-php.git\"))) \
+		        (treesit-install-language-grammar 'php))))))" \
+		-l ./tests/php-ts-mode-tests.el \
+		-f ert-run-tests-batch-and-exit
+
+.PHONY: all autoloads clean test

--- a/tests/php-ts-mode-resources/indent.erts
+++ b/tests/php-ts-mode-resources/indent.erts
@@ -1,0 +1,28 @@
+Code:
+  (lambda ()
+    (setq indent-tabs-mode nil)
+    (setq php-ts-mode-indent-offset 4)
+    (php-ts-mode)
+    (indent-region (point-min) (point-max)))
+
+Point-Char: |
+
+Name: Basic
+
+=-=
+class Basic {
+    public function basic(): void {
+        return;
+    }
+}
+=-=-=
+
+Name: Empty Line
+
+=-=
+class EmptyLine {
+    public function emptyLine(): void {
+        |
+    }
+}
+=-=-=

--- a/tests/php-ts-mode-resources/movement.erts
+++ b/tests/php-ts-mode-resources/movement.erts
@@ -1,0 +1,162 @@
+Code:
+  (lambda ()
+    (php-ts-mode)
+    (forward-sentence 1))
+
+Point-Char: |
+
+Name: forward-sentence moves over method invocation
+
+=-=
+class Basic
+{
+  public function basic(): void
+  {
+    |echo "some text: {$text}";
+  }
+}
+=-=
+class Basic
+{
+  public function basic(): void
+  {
+    echo "some text: {$text}";|
+  }
+}
+=-=-=
+
+Name: forward-sentence moves over if
+
+=-=
+class Basic
+{
+  public function basic(): void
+  {
+    |if ($x) {
+
+    }
+    echo "some text: {$text}";
+    return;
+  }
+}
+=-=
+class Basic
+{
+  public function basic(): void
+  {
+    if ($x) {
+
+    }|
+    echo "some text: {$text}";
+    return;
+  }
+}
+=-=-=
+
+Code:
+  (lambda ()
+    (php-ts-mode)
+    (forward-sentence 2))
+
+Name: forward-sentence moves over multiple statements
+
+=-=
+class Basic {
+  public function basic(): void {
+    |return;
+    return;
+  }
+}
+=-=
+class Basic {
+  public function basic(): void {
+    return;
+    return;|
+  }
+}
+=-=-=
+
+Code:
+  (lambda ()
+    (php-ts-mode)
+    (backward-sentence 1))
+
+Name: backward-sentence moves over one statement
+
+=-=
+class Basic {
+  public function basic(): void {
+    return;|
+  }
+}
+=-=
+class Basic {
+  public function basic(): void {
+    |return;
+  }
+}
+=-=-=
+
+Code:
+  (lambda ()
+    (php-ts-mode)
+    (beginning-of-defun))
+
+Name: beginning-of-defun moves to defun start
+
+=-=
+class Basic {
+  public function basic(): void {
+    return;|
+  }
+}
+=-=
+class Basic {
+|  public function basic(): void {
+    return;
+  }
+}
+=-=-=
+
+Code:
+  (lambda ()
+    (php-ts-mode)
+    (beginning-of-defun)
+    (beginning-of-defun))
+
+Name: beginning-of-defun moves to class
+
+=-=
+class Basic {
+  public function basic(): void {
+    return;|
+  }
+}
+=-=
+|class Basic {
+  public function basic(): void {
+    return;
+  }
+}
+=-=-=
+
+Code:
+  (lambda ()
+    (php-ts-mode)
+    (end-of-defun))
+
+Name: end-of-defun moves to defun end
+
+=-=
+class Basic {
+  public funtion basic(): void {
+    return;|
+  }
+}
+=-=
+class Basic {
+  public function basic(): void {
+    return;
+  }
+|}
+=-=-=

--- a/tests/php-ts-mode-tests.el
+++ b/tests/php-ts-mode-tests.el
@@ -1,0 +1,35 @@
+;;; php-ts-mode-tests.el --- Tests for Tree-sitter-based PHP mode  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2022-2023 Free Software Foundation, Inc.
+;; Copyright (C) 2023  Friends of Emacs-PHP development
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Code:
+
+(require 'ert)
+(require 'ert-x)
+(require 'treesit)
+
+(ert-deftest php-ts-mode-test-indentation ()
+  (skip-unless (treesit-ready-p 'php))
+  (ert-test-erts-file (ert-resource-file "indent.erts")))
+
+; FIXME: implement basic movements
+;(ert-deftest php-ts-mode-test-movement ()
+;  (skip-unless (treesit-ready-p 'php))
+; (ert-test-erts-file (ert-resource-file "movement.erts")))
+
+(provide 'php-ts-mode-tests)
+;;; php-ts-mode-tests.el ends here


### PR DESCRIPTION
Running tests:
```
make test
```

Currently movement tests fail.

For CI we will probably have to run on snapshot only for start.

Note I'm using emacs with treesitter from snap ubuntu repo. We could have a matrix with 29 and 30 if needed.
For now we cannot use due to issue with loading of php grammar in CI. It's tracked here https://github.com/purcell/nix-emacs-ci/issues/168 . I'll probably have to debug it locally and to recreate it but I would say it's outside of the scope for this PR and I doubt it's php-ts-mode codebase related.
