### PR TITLE
binary operator xor, and, or highlight

### DIFF
--- a/php-ts-mode.el
+++ b/php-ts-mode.el
@@ -205,7 +205,10 @@ the available version of Tree-sitter for PHP."
 
    :language 'php
    :feature 'operator
-   `([,@php-ts-mode--operators] @font-lock-operator-face)
+   `([,@php-ts-mode--operators] @font-lock-operator-face
+     (binary_expression operator: "xor" @font-lock-operator-face)
+     (binary_expression operator: "and" @font-lock-operator-face)
+     (binary_expression operator: "or" @font-lock-operator-face))
 
    :language 'php
    :feature 'keyword


### PR DESCRIPTION
https://github.com/emacs-php/php-ts-mode/issues/8

@zonuexe should these be highlighed as operators or keywords?
I'm fine with moving them to keywords as we have in `php-mode`.

![phptsbinaryoperator](https://github.com/emacs-php/php-ts-mode/assets/2151333/41b7970b-f5d2-45ca-8d81-9dbf1e8b7ca9)
