### PR TITLE
Use Nix to install a custom build of Emacs on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    paths-ignore:
+    - '**/*.md'
+    - 'etc/*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    strategy:
+      matrix:
+        emacs_version: ['release-snapshot']
+    steps:
+    - name: Install emacs
+      run: sudo snap install emacs --beta --classic
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Check emacs version
+      run: emacs --version
+    - name: Emacs support
+      run: emacs --batch --eval '(message "Treesit available %s" (treesit-available-p))'
+    - name: Run tests
+      run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,15 +12,20 @@ jobs:
     timeout-minutes: 3
     strategy:
       matrix:
-        emacs_version: ['release-snapshot']
+        emacs_version: ['emacs-release-snapshot']
     steps:
-    - name: Install emacs
-      run: sudo snap install emacs --beta --classic
+    - uses: cachix/install-nix-action@v21
+      with:
+        extra_nix_config: |
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+          accept-flake-config = true
     - name: Checkout repo
       uses: actions/checkout@v3
     - name: Check emacs version
-      run: emacs --version
+      run: nix develop .#${{ matrix.emacs_version }} -c emacs --version
     - name: Emacs support
-      run: emacs --batch --eval '(message "Treesit available %s" (treesit-available-p))'
+      run: |
+        nix develop .#${{ matrix.emacs_version }} -c \
+        emacs --batch --eval '(message "Treesit available %s" (treesit-available-p))'
     - name: Run tests
-      run: make test
+      run: nix develop .#${{ matrix.emacs_version }} -c make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.elc
+php-ts-mode-autoloads.el
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+EMACS ?= emacs
+ELS = php-ts-mode.el
+ELS += php-face.el
+ELCS = $(ELS:.el=.elc)
+AUTOLOADS = php-ts-mode-autoloads.el
+
+%.elc: %.el
+	$(EMACS) --batch -L $(ELS) -f batch-byte-compile $<
+
+all: autoloads $(ELCS)
+
+autoloads: $(AUTOLOADS)
+
+$(AUTOLOADS): $(ELS)
+	$(EMACS) --batch -L $(ELS) --eval \
+	"(let ((user-emacs-directory default-directory)) \
+	   (require 'package) \
+	   (package-generate-autoloads \"php-ts-mode\" (expand-file-name \".\")))"
+
+clean:
+	rm -rf $(ELCS) $(AUTOLOADS) tree-sitter
+
+test: clean all
+	$(EMACS) --batch \
+		-l php-ts-mode-autoloads.el \
+		--eval \
+		"(progn \
+		  (require 'treesit) \
+		  (declare-function treesit-install-language-grammar \"treesit.c\") \
+		  (if (and (treesit-available-p) (boundp 'treesit-language-source-alist)) \
+		      (unless (treesit-language-available-p 'php) \
+		        (add-to-list \
+		         'treesit-language-source-alist \
+		         '(php . (\"https://github.com/tree-sitter/tree-sitter-php.git\"))) \
+		        (treesit-install-language-grammar 'php))))))" \
+		-l ./tests/php-ts-mode-tests.el \
+		-f ert-run-tests-batch-and-exit
+
+.PHONY: all autoloads clean test

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "emacs-ci": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1685781476,
+        "narHash": "sha256-0Uu8GHMmvEcOEl5mmOhKg+njnyVekkGHpTKjvKagnFs=",
+        "owner": "purcell",
+        "repo": "nix-emacs-ci",
+        "rev": "2d97ed37cc1008bc307d5001799b55382646a89d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "purcell",
+        "repo": "nix-emacs-ci",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "emacs-ci": "emacs-ci",
+        "flake-utils": "flake-utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,55 @@
+{
+  nixConfig = {
+    extra-substituters = [
+      "https://emacs-ci.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "emacs-ci.cachix.org-1:B5FVOrxhXXrOL0S+tQ7USrhjMT5iOPH+QN9q0NItom4="
+    ];
+  };
+
+  inputs.emacs-ci = {
+    url = "github:purcell/nix-emacs-ci";
+    flake = false;
+  };
+
+  outputs = {
+    emacs-ci,
+    flake-utils,
+    ...
+  }: let
+  in
+    flake-utils.lib.eachDefaultSystem
+    (system: let
+      pkgs =
+        import ((import (emacs-ci + "/nix/sources.nix") {
+            inherit system;
+          })
+          .nixpkgs)
+        {
+          inherit system;
+          overlays = [
+            (import (emacs-ci + "/overlay.nix"))
+          ];
+        };
+
+      emacsCIWith = emacs:
+        (pkgs.emacs.pkgs.overrideScope'
+          (_: _: {
+            inherit emacs;
+          }))
+        .withPackages (epkgs: [
+          (epkgs.treesit-grammars.with-grammars (grammars: [grammars.tree-sitter-php]))
+        ]);
+
+      makeEmacsShell = emacs:
+        pkgs.mkShell {
+          buildInputs = [
+            (emacsCIWith emacs)
+          ];
+        };
+    in {
+      devShells.emacs-snapshot = makeEmacsShell pkgs.emacs-snapshot;
+      devShells.emacs-release-snapshot = makeEmacsShell pkgs.emacs-release-snapshot;
+    });
+}

--- a/tests/php-ts-mode-resources/indent.erts
+++ b/tests/php-ts-mode-resources/indent.erts
@@ -1,0 +1,28 @@
+Code:
+  (lambda ()
+    (setq indent-tabs-mode nil)
+    (setq php-ts-mode-indent-offset 4)
+    (php-ts-mode)
+    (indent-region (point-min) (point-max)))
+
+Point-Char: |
+
+Name: Basic
+
+=-=
+class Basic {
+    public function basic(): void {
+        return;
+    }
+}
+=-=-=
+
+Name: Empty Line
+
+=-=
+class EmptyLine {
+    public function emptyLine(): void {
+        |
+    }
+}
+=-=-=

--- a/tests/php-ts-mode-resources/movement.erts
+++ b/tests/php-ts-mode-resources/movement.erts
@@ -1,0 +1,162 @@
+Code:
+  (lambda ()
+    (php-ts-mode)
+    (forward-sentence 1))
+
+Point-Char: |
+
+Name: forward-sentence moves over method invocation
+
+=-=
+class Basic
+{
+  public function basic(): void
+  {
+    |echo "some text: {$text}";
+  }
+}
+=-=
+class Basic
+{
+  public function basic(): void
+  {
+    echo "some text: {$text}";|
+  }
+}
+=-=-=
+
+Name: forward-sentence moves over if
+
+=-=
+class Basic
+{
+  public function basic(): void
+  {
+    |if ($x) {
+
+    }
+    echo "some text: {$text}";
+    return;
+  }
+}
+=-=
+class Basic
+{
+  public function basic(): void
+  {
+    if ($x) {
+
+    }|
+    echo "some text: {$text}";
+    return;
+  }
+}
+=-=-=
+
+Code:
+  (lambda ()
+    (php-ts-mode)
+    (forward-sentence 2))
+
+Name: forward-sentence moves over multiple statements
+
+=-=
+class Basic {
+  public function basic(): void {
+    |return;
+    return;
+  }
+}
+=-=
+class Basic {
+  public function basic(): void {
+    return;
+    return;|
+  }
+}
+=-=-=
+
+Code:
+  (lambda ()
+    (php-ts-mode)
+    (backward-sentence 1))
+
+Name: backward-sentence moves over one statement
+
+=-=
+class Basic {
+  public function basic(): void {
+    return;|
+  }
+}
+=-=
+class Basic {
+  public function basic(): void {
+    |return;
+  }
+}
+=-=-=
+
+Code:
+  (lambda ()
+    (php-ts-mode)
+    (beginning-of-defun))
+
+Name: beginning-of-defun moves to defun start
+
+=-=
+class Basic {
+  public function basic(): void {
+    return;|
+  }
+}
+=-=
+class Basic {
+|  public function basic(): void {
+    return;
+  }
+}
+=-=-=
+
+Code:
+  (lambda ()
+    (php-ts-mode)
+    (beginning-of-defun)
+    (beginning-of-defun))
+
+Name: beginning-of-defun moves to class
+
+=-=
+class Basic {
+  public function basic(): void {
+    return;|
+  }
+}
+=-=
+|class Basic {
+  public function basic(): void {
+    return;
+  }
+}
+=-=-=
+
+Code:
+  (lambda ()
+    (php-ts-mode)
+    (end-of-defun))
+
+Name: end-of-defun moves to defun end
+
+=-=
+class Basic {
+  public funtion basic(): void {
+    return;|
+  }
+}
+=-=
+class Basic {
+  public function basic(): void {
+    return;
+  }
+|}
+=-=-=

--- a/tests/php-ts-mode-tests.el
+++ b/tests/php-ts-mode-tests.el
@@ -1,0 +1,35 @@
+;;; php-ts-mode-tests.el --- Tests for Tree-sitter-based PHP mode  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2022-2023 Free Software Foundation, Inc.
+;; Copyright (C) 2023  Friends of Emacs-PHP development
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Code:
+
+(require 'ert)
+(require 'ert-x)
+(require 'treesit)
+
+(ert-deftest php-ts-mode-test-indentation ()
+  (skip-unless (treesit-ready-p 'php))
+  (ert-test-erts-file (ert-resource-file "indent.erts")))
+
+; FIXME: implement basic movements
+;(ert-deftest php-ts-mode-test-movement ()
+;  (skip-unless (treesit-ready-p 'php))
+; (ert-test-erts-file (ert-resource-file "movement.erts")))
+
+(provide 'php-ts-mode-tests)
+;;; php-ts-mode-tests.el ends here


### PR DESCRIPTION
This PR is based on #13 but uses Nix to install Emacs with the tree-sitter parser for PHP.

You can also run the tests locally if you have Nix. First you have to add the following settings to `nix.conf` (`~/.config/nix/nix.conf` on Linux):

```
experimental-features = nix-command flakes
```

Then use the following command:

```
nix develop .#emacs-release-snapshot --accept-flake-config -c make test
```

You need `make` on your machine. Some users may not have one, so it would be better to add it to `buildInputs` in `flake.nix`:

```nix
  pkgs.mkShell {
    buildInputs = [
      pkgs.gnumake
      (emacsCIWith emacs)
    ];
  };
```

Note that `gnumake` may add some extra download time on CI.