### PR TITLE
Modify php-ts-mode--font-lock-settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ If you don't already have `php-ts-mode` installed, please evaluate the Lisp code
 
 Running `M-x treesit-install-language-grammar [RET] php` will compile and install the latest [tree-sitter-php][].
 
+## Settings
+
+### Syntax highlighting
+
+In `php-ts-mode`, syntax elements are classified as follows.
+
+ * **Level 1**: `comment` `definition` `preprocessor`
+ * **Level 2**: `keyword` `string` `type`
+ * **Level 3**: `function` `constant` `label`
+ * **Level 4**: `bracket` `delimiter` `operator` `variables`
+
+By default, up to **Level 3** will be highlighted.
+
 ## How to develop
 
  1. Chekout [tree-sitter-php][] to your computer.

--- a/php-ts-mode.el
+++ b/php-ts-mode.el
@@ -35,6 +35,7 @@
 (require 'treesit)
 (require 'c-ts-common)
 (require 'php nil t)
+(require 'php-face nil t)
 
 (declare-function php-base-mode "ext:php")
 (declare-function treesit-parser-create "treesit.c")
@@ -122,26 +123,44 @@ see https://www.php.net/manual/language.constants.predefined.php")
 
    :language 'php
    :feature 'preprocessor
-   `((php_tag) @font-lock-preprocessor-face
-     ("?>") @font-lock-preprocessor-face)
+   `([(php_tag)
+      ("?>")]
+     @php-php-tag)
 
    :language 'php
    :feature 'constant
    `((const_declaration (const_element (name) @font-lock-type-face))
-     (null) @php-constant)
+     ((name) @php-magical-constant
+      (:match ,(rx-to-string `(: bos (or ,@php-ts-mode--magical-constants) eos))
+              @php-magical-constant))
+     ((name) @php-constant
+      (:match ,(rx bos (? "_") (in "A-Z") (+ (in "0-9A-Z_")) eos)
+              @php-constant)))
 
    :language 'php
    :feature 'type
    `([(primitive_type)
       (cast_type)
       (bottom_type)
-      (named_type (name) @type)
-      (named_type (qualified_name) @type)
+      (named_type (name) @php-type)
+      (named_type (qualified_name) @php-type)
       (namespace_use_clause)
-      (namespace_name (name))
-      (boolean)]
-     @font-lock-type-face
-     (class_interface_clause (name) @font-lock-type-face)
+      (namespace_name (name))]
+     @php-type
+     (class_interface_clause (name) @php-class)
+     (class_constant_access_expression
+      (name) @php-keyword
+      (:match ,(rx bos "class" eos)
+              @php-keyword))
+     (class_constant_access_expression
+      (name) @php-constant
+      (:match ,(rx bos (? "_") (in "A-Z") (+ (in "0-9A-Z_")) eos)
+              @php-constant))
+     (class_constant_access_expression
+      (name) @php-class)
+     [(boolean)
+      (null)]
+     @php-constant
      [(integer)
       (float)]
      @font-lock-number-face)
@@ -149,49 +168,52 @@ see https://www.php.net/manual/language.constants.predefined.php")
    :language 'php
    :feature 'definition
    `((class_declaration
-      name: (name) @font-lock-type-face)
+      name: (name) @php-class)
      (interface_declaration
-      name: (name) @font-lock-type-face)
+      name: (name) @php-class)
      (enum_declaration
-      name: (name) @font-lock-type-face)
+      name: (name) @php-class)
      (trait_declaration
-      name: (name) @font-lock-type-face)
+      name: (name) @php-class)
      (enum_case
-      name: (name) @font-lock-type-face))
+      name: (name) @php-class))
 
    :language 'php
    :feature 'function
-   `((array_creation_expression "array" @font-lock-builtin-face)
-     (list_literal "list" @font-lock-builtin-face)
+   `((array_creation_expression "array" @php-builtin)
+     (list_literal "list" @php-builtin)
      (method_declaration
-      name: (name) @font-lock-function-name-face)
+      name: (name) @php-function-name)
      (function_call_expression
-      function: [(qualified_name (name)) (name)] @font-lock-function-call-face)
+      function: [(qualified_name (name)) (name)] @php-function-call)
      (scoped_call_expression
-      name: (name) @font-lock-function-call-face)
+      scope: (name) @php-class)
+     (scoped_call_expression
+      name: (name) @php-static-method-call)
      (member_call_expression
-      name: (name) @font-lock-function-call-face)
-     (object_creation_expression (name) @font-lock-type-face)
+      name: (name) @php-method-call)
+     (object_creation_expression (name) @php-class)
+     (attribute (name) @php-class)
+     (attribute (qualified_name) @php-class)
+
      (function_definition
-      name: (name) @font-lock-function-name-face))
+      name: (name) @php-function-name))
 
    :language 'php
    :feature 'variables
    `((relative_scope) @font-lock-builtin-face
-     ((name) @font-lock-constant-face
-      (:match ,(rx bos (? "_") (in "A-Z") (in "0-9A-Z_") eos)
-              @font-lock-constant-face))
-     ((name) @font-lock-builtin-face
-      (:match ,(rx-to-string `(: bos (or ,@php-ts-mode--magical-constants) eos))
-              @font-lock-builtin-face))
+     (property_element
+      (variable_name) @php-property-name)
 
      ;; ((name) @constructor
      ;;  (:match ,(rx-to-string '(: bos (in "A-Z")))))
 
-     ;; ((name) @font-lock-variable-name-face
-     ;;  (#eq? @php-$this "this"))
+     ;; (variable_name (name) @php-$this
+     ;;  (:match ,(rx bos "this" eos)
+     ;;          @php-$this))
      (member_access_expression name: (name) @php-property-name)
-     (variable_name (name) @font-lock-variable-name-face)
+     ;;(variable_name (name) @font-lock-variable-name-face)
+     (variable_name (name) @php-variable-name)
      (variable_name "$" @php-variable-sigil))
 
    :language 'php
@@ -209,23 +231,30 @@ see https://www.php.net/manual/language.constants.predefined.php")
       (heredoc)
       (heredoc_body)
       (nowdoc_body)]
-     @font-lock-string-face)
+     @php-string)
 
    :language 'php
    :feature 'operator
-   `([,@php-ts-mode--operators] @font-lock-operator-face
-     (binary_expression operator: "xor" @font-lock-operator-face)
-     (binary_expression operator: "and" @font-lock-operator-face)
-     (binary_expression operator: "or" @font-lock-operator-face))
+   `([,@php-ts-mode--operators] @php-operator
+     (binary_expression operator: ["and" "or" "xor"] @php-operator))
 
    :language 'php
    :feature 'keyword
-   `([,@php-ts-mode--keywords] @font-lock-keyword-face
-     (yield_expression "from" @font-lock-keyword-face))
+   `([,@php-ts-mode--keywords] @php-keyword
+     (print_intrinsic "print" @php-keyword)
+     (goto_statement "goto" @php-keyword)
+     (yield_expression "from" @php-keyword))
+
+   :language 'php
+   :feature 'label
+   `((goto_statement (name) @php-keyword)
+     (named_label_statement (name) @php-keyword))
 
    :language 'php
    :feature 'delimiter
-   '((["," ":" ";" "\\"]) @font-lock-delimiter-face)
+   '((["," ":" ";" "\\"]) @font-lock-delimiter-face
+     (class_constant_access_expression "::" @font-lock-preprocessor-face)
+     (attribute_group ["#[" "]"] @font-lock-preprocessor-face))
 
    :language 'php
    :feature 'bracket
@@ -280,7 +309,7 @@ Currently there are `php-mode' and `php-ts-mode'."
   (setq-local c-ts-common-indent-type-regexp-alist
               (eval-when-compile
                 `((block . ,(rx (or "class_body"
-                                    "array_initializer"
+                                    "array_creation_expression"
                                     "constructor_body"
                                     "annotation_type_body"
                                     "interface_body"
@@ -307,7 +336,7 @@ Currently there are `php-mode' and `php-ts-mode'."
   (setq-local treesit-font-lock-feature-list
               '((comment definition preprocessor)
                 (keyword string type)
-                (function constant)
+                (function constant label)
                 (bracket delimiter operator variables)))
 
   ;; Imenu.


### PR DESCRIPTION
* Now properly highlight more keywords
* Support `goto` label
* Relying directly on faces defined in php-face.el for many highlights