### PR TITLE
remove redundant treesit language source set in tests

### DIFF
--- a/tests/php-ts-mode-tests.el
+++ b/tests/php-ts-mode-tests.el
@@ -26,11 +26,7 @@
 
 (if (and (treesit-available-p) (boundp 'treesit-language-source-alist))
     (unless (treesit-language-available-p 'php)
-      (add-to-list
-       'treesit-language-source-alist
-       '(php . ("https://github.com/tree-sitter/tree-sitter-php.git" "master" "php/src")))
       (treesit-install-language-grammar 'php)))
-
 
 (ert-deftest php-ts-mode-test-indentation ()
   (skip-unless (treesit-ready-p 'php))


### PR DESCRIPTION
As you fixed autoload list in https://github.com/emacs-php/php-ts-mode/pull/59 
Additional load in tests shouldn't be needed.