### PR TITLE
Fix multiline if statement indentation

### DIFF
--- a/php-ts-mode.el
+++ b/php-ts-mode.el
@@ -84,7 +84,7 @@
        ((parent-is "formal_parameters") parent-bol ,offset)
        ((parent-is "arguments") parent-bol ,offset)
        ((parent-is "parenthesized_expression") parent-bol ,offset)
-       ((parent-is "binary_expression") parent-bol, 0)
+       ((parent-is "binary_expression") parent 0)
        ((parent-is "switch_block") parent-bol ,offset)
        ((parent-is "case_statement") parent-bol ,offset)
        ((parent-is "default_statement") parent-bol ,offset)

--- a/tests/php-ts-mode-resources/indent.erts
+++ b/tests/php-ts-mode-resources/indent.erts
@@ -158,3 +158,21 @@ match ($t) {
     1 => 1
 };
 =-=-=
+
+Name: Multi-line if
+
+=-=
+<?php
+if ($testing &&
+$testing2
+&& true
+) {
+}
+=-=
+<?php
+if ($testing &&
+    $testing2
+    && true
+) {
+}
+=-=-=


### PR DESCRIPTION
Currently a multiline if statement is indented as follows:
```php
if ($testing &&
$testing2
&& true
) {
    // do something
}
```

But instead should be indented as:
```php
if ($testing &&
    $testing2
    && true
) {
    // do something
}
```

This change fixes this.